### PR TITLE
Parameterize base image, revert tag and update validation URL

### DIFF
--- a/roles/catapult/defaults/main.yml
+++ b/roles/catapult/defaults/main.yml
@@ -1,4 +1,5 @@
 ---
+base_image: openshift/wildfly-100-centos7
 oc_bianry: /home/kontinuity/oc/oc
 git_source_repository: https://github.com/redhat-kontinuity/catapult
 git_source_ref: master

--- a/roles/catapult/files/init_catapult.sh
+++ b/roles/catapult/files/init_catapult.sh
@@ -29,8 +29,11 @@ do
     -p=*|--password=*)
       PASSWORD="${i#*=}"
       shift;;
-     -b=*|--binary=*)
+    -b=*|--binary=*)
       OC_BINARY="${i#*=}"
+      shift;;
+    --base-image=*)
+      BASE_IMAGE="${i#*=}"
       shift;;      
     --github-client-id=*)
       KONTINUITY_CATAPULT_GITHUB_APP_CLIENT_ID="${i#*=}"

--- a/roles/catapult/tasks/provision-catapult.yml
+++ b/roles/catapult/tasks/provision-catapult.yml
@@ -1,5 +1,5 @@
 - name: Execute Catapult Init Script
-  script: init_catapult.sh -b={{ oc_binary }} -h={{ ose_host }} --github-client-id={{ github_client_id }} --github-client-secret={{ github_client_secret }} --git-repository={{ git_source_repository }} --git-ref={{ git_source_ref }}
+  script: init_catapult.sh -b={{ oc_binary }} -h={{ ose_host }} --github-client-id={{ github_client_id }} --github-client-secret={{ github_client_secret }} --base-image={{ base_image }} --git-repository={{ git_source_repository }} --git-ref={{ git_source_ref }}
   register: catapult_init_script
 
 - name: Debug Output

--- a/roles/common/tasks/start-openshift.yml
+++ b/roles/common/tasks/start-openshift.yml
@@ -6,11 +6,11 @@
   when: vagrantfile_exists.stat.exists == False
   # shell: cd && scl enable sclo-vagrant1 'bash -c "vagrant init projectatomic/adb && vagrant up"'
 
-- name: Set Image Tag
-  lineinfile:
-    dest: '/root/Vagrantfile'
-    line: 'IMAGE_TAG="latest"'
-    regexp: '^IMAGE_TAG'
+#- name: Set Image Tag
+#  lineinfile:
+#    dest: '/root/Vagrantfile'
+#    line: 'IMAGE_TAG="latest"'
+#    regexp: '^IMAGE_TAG'
 
 - name: Set Vagrantfile Host variable
   lineinfile:


### PR DESCRIPTION
Several modifications:
- Parameterized the base image to account for issues in upstream wildfly compatibility
- Reverted the image tag from latest to v1.1.1 due to issues in upstream image
- Updated catapult validation URL due to changes in context path of application 
